### PR TITLE
add stack.yaml for easy building with stack

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+resolver: lts-14.20
+packages:
+- .
+extra-deps:
+- monoid-subclasses-1.0
+- github: blamario/incremental-parser
+  commit: 13027e49ad59b0009a12bf3e693348a45916c918


### PR DESCRIPTION
Building is a bit tricky as it depends on github version of `incremental-parser`. Using `stack` to specify that makes building easy (btw same can also be done with `nix` or `cabal-v3`)